### PR TITLE
Update Hytale launcher version to version 2026.01.13-b6c7e88

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,10 @@
     let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
 
-      version = "2026.01.12-e43ec47";
+      version = "2026.01.12-b6c7e88";
       hytale-launcher-bin = pkgs.fetchzip {
         url = "https://launcher.hytale.com/builds/release/linux/amd64/hytale-launcher-${version}.zip";
-        sha256 = "sha256-OtfhmPQPmmrwp/1XYcbefj6PMxEEbOE5RSTECCZaguc=";
+        sha256 = "sha256-tjWGmuEfkzVuIyOCaClOAXofocZ+2hl9nrArwdxqHkc=";
       };
     in
     {


### PR DESCRIPTION
Maybe it could be a good idea to indicate to people how to find a newer version when an update arrives?

Like looking at the downloaded version shown when the launcher attempts to download an update?